### PR TITLE
Removing bad quote simbol

### DIFF
--- a/1.02-Exercise-InstallGradle/build.gradle
+++ b/1.02-Exercise-InstallGradle/build.gradle
@@ -52,7 +52,7 @@ export GRADLE_HOME=/usr/local/gradle/gradle-2.7
 PATH=$GRADLE_HOME/bin:$PATH
 export PATH
 # Turning on the Gradle daemon by default
-export GRADLE_OPTS="-Dorg.gradle.daemon=true"' >> ~/.bash_profile &&\
+export GRADLE_OPTS="-Dorg.gradle.daemon=true" >> ~/.bash_profile &&\
 source ~/.bash_profile
 
 ******************* Windows Instructions *******************


### PR DESCRIPTION
I'm not sure if this was suposed to be there, but that quote mark was messing my terminal putting > like I was suposed to keep writing something.