### PR TITLE
Dependencies mismatch

### DIFF
--- a/2.06-Exercise-DeclareARepositoryAndDependencies/solution.gradle
+++ b/2.06-Exercise-DeclareARepositoryAndDependencies/solution.gradle
@@ -9,7 +9,8 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-io:commons-io:2.4' // 2. Add commons-io dependency
+    compile 'org.lucee:commons-io:2.4' // 2. Add commons-io dependency. commons-io:commons-io:20030203.000550 
+                                       //if GroupId is commons-io
     compile fileTree(dir: 'libs', include: '*.jar') // 3. Add 'lib' directory
 }
 


### PR DESCRIPTION
Replaced 'commons-io:commons-io:2.4' with 'org.lucee:commons-io:2.4' .
We have to change it to 'commons-io:commons-io:20030203.000550' if we use GroupId as 'commons-io'