### PR TITLE
launchLibraryActivity in imageactivity module is redundant and confusing

### DIFF
--- a/4.03-Demo-CreatingAnAndroidLibrary/imageactivity/src/main/java/com/udacity/gradle/imageactivity/ImageActivity.java
+++ b/4.03-Demo-CreatingAnAndroidLibrary/imageactivity/src/main/java/com/udacity/gradle/imageactivity/ImageActivity.java
@@ -1,11 +1,9 @@
 package com.udacity.gradle.imageactivity;
 
-import android.content.Intent;
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 
 
 public class ImageActivity extends ActionBarActivity {
@@ -37,10 +35,5 @@ public class ImageActivity extends ActionBarActivity {
         }
 
         return super.onOptionsItemSelected(item);
-    }
-
-    public void launchLibraryActivity(View view){
-        Intent myIntent = new Intent(this, ImageActivity.class);
-        startActivity(myIntent);
     }
 }


### PR DESCRIPTION
`launchLibraryActivity` in imageactivity module of 4.03-Demo-CreatingAndroidLibrary is redundant. It is never used and it confuses student. onClick = "launchLibraryActivity" in app modules can't run methods in other module. It gives an impression that someone you have to create similar methods in multiple modules.